### PR TITLE
Fix enrol url

### DIFF
--- a/request.php
+++ b/request.php
@@ -98,7 +98,7 @@ function print_coursetable($teacher, $appendix = "") {
 
 function print_final() {
     global $OUTPUT, $CFG, $courseid;
-    echo $OUTPUT->box("<b>" . get_string('next_steps', 'local_lsf_unification') . ":</b><br><a href='" . $CFG->wwwroot . "/enrol/users.php?id=" . ($courseid) . "'>" . get_string('linktext_users', 'local_lsf_unification') . "</a><br>
+    echo $OUTPUT->box("<b>" . get_string('next_steps', 'local_lsf_unification') . ":</b><br><a href='" . $CFG->wwwroot . "/user/index.php?id=" . ($courseid) . "'>" . get_string('linktext_users', 'local_lsf_unification') . "</a><br>
     <a href='" . $CFG->wwwroot . "/course/view.php?id=" . ($courseid) . "'>" . get_string('linktext_course', 'local_lsf_unification') . "</a><br>&nbsp;");
 }
 

--- a/version.php
+++ b/version.php
@@ -24,6 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2013090304;
+$plugin->version  = 2018032100;
 $plugin->component = 'local_lsf_unification';
 $plugin->cron      = 86400;      // once a day
+$plugin->requires  = 2017111300; // Moodle 3.4


### PR DESCRIPTION
In Moodle 3.4 the participants page and the enrolment page were merged. Therefore, the URL that we referenced became obsolete. This patch addresses that.