### PR TITLE
Fix typo: requestor -> requester

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -197,7 +197,7 @@ class provider implements \core_privacy\local\metadata\provider, \core_privacy\l
         if ($context->contextlevel == CONTEXT_USER ) {
             $userid = $context->instanceid;
             $DB->delete_records("local_lsf_course", array('acceptorid' => $userid));
-            $DB->delete_records("local_lsf_course", array('requestorid' => $userid));
+            $DB->delete_records("local_lsf_course", array('requesterid' => $userid));
         }
     }
 
@@ -222,7 +222,7 @@ class provider implements \core_privacy\local\metadata\provider, \core_privacy\l
 
             $userid = $context->instanceid;
             $DB->delete_records("local_lsf_course", array('acceptorid' => $userid));
-            $DB->delete_records("local_lsf_course", array('requestorid' => $userid));
+            $DB->delete_records("local_lsf_course", array('requesterid' => $userid));
         }
     }
 }


### PR DESCRIPTION
Löschanfrage scheiterte partiell mit folgender Meldung:

```
Beim Aufruf von local_lsf_unification\privacy\provider::delete_data_for_user ist ein Fehler aufgetreten.
Das Plugin local_lsf_unification hat die Verarbeitung der Daten nicht beendet. Unten finden Sie Informationen für den Pluginentwickler.

Feld "requestorid" existiert nicht in der Tabelle "local_lsf_course"


#0 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/lib/dml/moodle_database.php(1939): moodle_database->where_clause('local_lsf_cours...', Array)
#1 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/local/lsf_unification/classes/privacy/provider.php(225): moodle_database->delete_records('local_lsf_cours...', Array)
#2 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/privacy/classes/local/legacy_polyfill.php(103): local_lsf_unification\privacy\provider::_delete_data_for_user(Object(core_privacy\local\request\approved_contextlist))
#3 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/lib/moodlelib.php(7960): local_lsf_unification\privacy\provider::delete_data_for_user(Object(core_privacy\local\request\approved_contextlist))
#4 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/privacy/classes/manager.php(578): component_class_callback('local_lsf_unifi...', 'delete_data_for...', Array)
#5 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/privacy/classes/manager.php(611): core_privacy\manager::component_class_callback('local_lsf_unifi...', 'core_privacy\\lo...', 'delete_data_for...', Array)
#6 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/privacy/classes/manager.php(415): core_privacy\manager->handled_component_class_callback('local_lsf_unifi...', 'core_privacy\\lo...', 'delete_data_for...', Array)
#7 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/admin/tool/dataprivacy/classes/task/process_data_request_task.php(134): core_privacy\manager->delete_data_for_user(Object(core_privacy\local\request\contextlist_collection))
#8 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/lib/cronlib.php(272): tool_dataprivacy\task\process_data_request_task->execute()
#9 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/lib/cronlib.php(155): cron_run_inner_adhoc_task(Object(tool_dataprivacy\task\process_data_request_task))
#10 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/lib/cronlib.php(76): cron_run_adhoc_tasks(1568650884)
#11 /www/data/LearnWeb/htdocs/LearnWeb/learnweb2/admin/cli/cron.php(61): cron_run()
#12 {main}
```

Dies sollte das Problem beheben.